### PR TITLE
Fix Threading.Event.wait on Linux systems

### DIFF
--- a/Sources/Threading.swift
+++ b/Sources/Threading.swift
@@ -41,6 +41,10 @@ private func my_pthread_cond_timedwait_relative_np(_ cond: UnsafeMutablePointer<
 	clock_gettime(CLOCK_MONOTONIC, &timeout)
 	timeout.tv_sec += tmspec.pointee.tv_sec
 	timeout.tv_nsec += tmspec.pointee.tv_nsec
+	if timeout.tv_nsec >= 1000000000 {
+		timeout.tv_sec += 1
+		timeout.tv_nsec -= 1000000000
+	}
 	let i = pthread_cond_timedwait(cond, mutx, &timeout)
 #endif
 	return i


### PR DESCRIPTION
Hi,
The 'tv_nsec' range should be kept inside [0, 999999999]. Some Linux systems return EINVAL if the nano value is more than 1 second.