### PR TITLE
Adding interface `doWithLockFor<Result>`

### DIFF
--- a/Sources/Threading.swift
+++ b/Sources/Threading.swift
@@ -108,14 +108,14 @@ public extension Threading {
 			try closure()
 		}
 
-    /// Acquire the lock, execute the closure, release the lock.
-    public func doWithLockFor<Result>(closure: () throws -> Result) rethrows -> Result {
-      let _ = self.lock()
-      defer {
-        let _ = self.unlock()
-      }
-      return try closure()
-    }
+        /// Acquire the lock, execute the closure, release the lock.
+		public func doWithLockFor<Result>(closure: () throws -> Result) rethrows -> Result {
+			let _ = self.lock()
+			defer {
+				let _ = self.unlock()
+			}
+			return try closure()
+		}
 	}
 }
 

--- a/Sources/Threading.swift
+++ b/Sources/Threading.swift
@@ -107,6 +107,15 @@ public extension Threading {
 			}
 			try closure()
 		}
+
+    /// Acquire the lock, execute the closure, release the lock.
+    public func doWithLockFor<Result>(closure: () throws -> Result) rethrows -> Result {
+      let _ = self.lock()
+      defer {
+        let _ = self.unlock()
+      }
+      return try closure()
+    }
 	}
 }
 


### PR DESCRIPTION
This patch is for closures that need a return value.